### PR TITLE
vp9_decode: Add memset to initialize memory of pMDFBuffer1/2D

### DIFF
--- a/src/vp9hdec/decode_hybrid_vp9.cpp
+++ b/src/vp9hdec/decode_hybrid_vp9.cpp
@@ -503,6 +503,7 @@ INTEL_HYBRID_VP9_ALLOCATE_MDF_2DUP_BUFFER_UINT8(
 	goto allocation_fail;
     }
     dri_bo_map(pMdfBuffer2D->bo, 1);
+    memset(pMdfBuffer2D->bo->virt, 0, buf_size);
     pMdfBuffer2D->pBuffer = pMdfBuffer2D->bo->virt;
     pMdfBuffer2D->bo_mapped = 1;
 
@@ -576,6 +577,7 @@ VAStatus INTEL_HYBRID_VP9_ALLOCATE_MDF_1D_BUFFER_UINT8(
     }
   
     dri_bo_map(pMdfBuffer1D->bo, 1);
+    memset(pMdfBuffer1D->bo->virt, 0, buf_size);
     pMdfBuffer1D->pu8Buffer = (UINT8 *)pMdfBuffer1D->bo->virt;
     pMdfBuffer1D->bo_mapped = 1;
     
@@ -628,6 +630,7 @@ INTEL_HYBRID_VP9_ALLOCATE_MDF_1D_BUFFER_UINT16(
     }
   
     dri_bo_map(pMdfBuffer1D->bo, 1);
+    memset(pMdfBuffer1D->bo->virt, 0, buf_size);
     pMdfBuffer1D->pu16Buffer = (UINT16 *) pMdfBuffer1D->bo->virt;
     pMdfBuffer1D->bo_mapped = 1;
 
@@ -682,6 +685,7 @@ INTEL_HYBRID_VP9_ALLOCATE_MDF_1D_BUFFER_UINT32(
     }
   
     dri_bo_map(pMdfBuffer1D->bo, 1);
+    memset(pMdfBuffer1D->bo->virt, 0, buf_size);
     pMdfBuffer1D->pu32Buffer = (UINT32 *)pMdfBuffer1D->bo->virt;
     pMdfBuffer1D->bo_mapped = 1;
 
@@ -734,6 +738,7 @@ INTEL_HYBRID_VP9_ALLOCATE_MDF_1D_BUFFER_UINT64(
     }
   
     dri_bo_map(pMdfBuffer1D->bo, 1);
+    memset(pMdfBuffer1D->bo->virt, 0, buf_size);
     pMdfBuffer1D->pu64Buffer = (UINT64 *)pMdfBuffer1D->bo->virt;
     pMdfBuffer1D->bo_mapped = 1;
 


### PR DESCRIPTION
This is to fix R2R when playing the clip of Smaller_VP9_209_extra_smaller_1.1.vp9 on HSW.

Signed-off-by: Wei Lin wei.w.lin@intel.com
