### PR TITLE
va_wrapper: free search_path in init_i965_contex

### DIFF
--- a/src/va_wrapper.c
+++ b/src/va_wrapper.c
@@ -587,6 +587,8 @@ CHECK:
         driver_dir = strtok_r(NULL, ":", &saveptr);
   }
 
+  free(search_path);
+
   return ctx;
 }
 


### PR DESCRIPTION
The search_path is dup'd in init_i965_contex() but
never free'd.  Thus, free it before returning.

Signed-off-by: U. Artie Eoff ullysses.a.eoff@intel.com
