### PR TITLE
vp9_hdec: fix segment fault on CPBAC engine filling compressed bit st…

### DIFF
--- a/src/vp9hdec/intel_hybrid_hostvld_vp9_engine.h
+++ b/src/vp9hdec/intel_hybrid_hostvld_vp9_engine.h
@@ -76,6 +76,27 @@
 #define BAC_ENG_PROB_RANGE      ( 1 << BAC_ENG_PROB_BITS )
 #define BAC_ENG_PROB_HALF       ( 1 << (BAC_ENG_PROB_BITS-1) )
 
+// Read 16-bit or Read 8-bit for the last even byte to fill BAC engine
+#define INTEL_HOSTVLD_VP9_BACENGINE_FILL()           \
+do                                                      \
+{ \
+    if (iCount < BAC_ENG_VALUE_HEAD_RSRV)                                     \
+    {                                                   \
+	if ((pBacEngine->pBufEnd - pBacEngine->pBuf) >= 2 ) { \
+		register UINT16 ui16RegOp = *((PUINT16)(pBacEngine->pBuf));                     \
+		BacValue |= (ui16RegOp & 0xFF) << (BAC_ENG_VALUE_BITS - BYTE_BITS - iCount);    \
+		BacValue |= (ui16RegOp & 0xFF00) << (BYTE_BITS - iCount);                       \
+		pBacEngine->pBuf += 2;                          \
+		iCount += (BYTE_BITS << 1);                     \
+	} else { \
+		register UINT8 ui8RegOp = *((PUINT8)(pBacEngine->pBuf));                     \
+		BacValue |= (ui8RegOp & 0xFF) << (BAC_ENG_VALUE_BITS - BYTE_BITS - iCount);    \
+		pBacEngine->pBuf += 1;                          \
+		iCount += BAC_ENG_MASSIVE_BITS;                     \
+	} \
+    }                                                   \
+} while (0)
+
 extern const UCHAR g_Vp9NormTable[BAC_ENG_MAX_RANGE+1];
 
 INT Intel_HostvldVp9_BacEngineInit(

--- a/src/vp9hdec/intel_hybrid_hostvld_vp9_parser.cpp
+++ b/src/vp9hdec/intel_hybrid_hostvld_vp9_parser.cpp
@@ -95,20 +95,6 @@
 #define VP9_GET_TX_TYPE(TxSize, IsLossLess, PredModeLuma) \
     (((TxSize) == TX_4X4 && (IsLossLess))? TX_DCT : g_Vp9Mode2TxTypeMap[(PredModeLuma)])
 
-// Read 16-bit and fill BAC engine
-#define INTEL_HOSTVLD_VP9_BACENGINE_FILL()           \
-do                                                      \
-{                                                       \
-    if (iCount < 8)                                     \
-    {                                                   \
-        register UINT16 ui16RegOp = *((PUINT16)(pBacEngine->pBuf));                     \
-        BacValue |= (ui16RegOp & 0xFF) << (BAC_ENG_VALUE_BITS - BYTE_BITS - iCount);    \
-        BacValue |= (ui16RegOp & 0xFF00) << (BYTE_BITS - iCount);                       \
-        pBacEngine->pBuf += 2;                          \
-        iCount += (BYTE_BITS << 1);                     \
-    }                                                   \
-} while (0)
-
 // Shift BAC engine
 #define INTEL_HOSTVLD_VP9_BACENGINE_SHIFT()          \
 do                                                      \


### PR DESCRIPTION
…ream.

```
 (1) Below commit fixed the seg fault, but regression happened.
           "
            commit 680819ffb987bc2ceacfb49b2b278e70df97d84e
            Author: Zhao Yakui <yakui.zhao@intel.com>

            This is to follow what is done in VP9 reference code and avoid the cross
            boundary issue when reading data from compressed bits. Otherwise it
            will trigger the segment fault issue when playing back some VP9 clips.
            "
 (2) Two main changes in this fix:
     1. BAC filling function adds a buf length checking and a byte-read for the last even byte to avoid segfault.
     2. BAC init function applys above filling function if the bit stream buf length is less than 4-byte.
 (3) Referencing libvpx::vp9_reader.c::vp9_reader_fill().
```

Signed-off-by: Wei Lin wei.w.lin@intel.com
