### PR TITLE
Fix the CMRT name to libcmrt.so

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -129,7 +129,7 @@ hybrid_drv_video_ladir= $(LIBVA_DRIVERS_PATH)
 hybrid_drv_video_la_CFLAGS	= $(driver_cflags)
 hybrid_drv_video_la_CXXFLAGS	= -fpermissive $(driver_cflags)
 hybrid_drv_video_la_LDFLAGS= $(driver_ldflags)
-hybrid_drv_video_la_LIBADD	= $(driver_files) vp9hdec/vp9hdec.la -l:cmrt.so
+hybrid_drv_video_la_LIBADD	= $(driver_files) vp9hdec/vp9hdec.la -l:libcmrt.so
 hybrid_drv_video_la_SOURCES= $(driver_files)
 noinst_HEADERS = $(driver_headers)
 


### PR DESCRIPTION
Signed-off-by: Sameer Kibey sameer.kibey@intel.com
