### PR TITLE
Fix out-of-tree builds

### DIFF
--- a/src/vp9hdec/Makefile.am
+++ b/src/vp9hdec/Makefile.am
@@ -26,6 +26,7 @@ AM_CPPFLAGS = \
 	-DPTHREADS		\
 	$(DRM_CFLAGS)		\
 	$(LIBVA_DEPS_CFLAGS)	\
+	-I$(top_srcdir)/src	\
 	-I$(top_srcdir)/src/cmrt	\
 	-D__linux__		\
 	-DLINUX		\


### PR DESCRIPTION
Building out of tree failed because of missing headers from src.
